### PR TITLE
Corrects seed script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "seed": "ts-node ./scripts/populateDb.ts",
+    "seed": "ts-node ./scripts/loadDb.ts",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
I think the script you used to seed the db changed name at some point, but the script in package.json didn't keep up.

This corrects the script to run `scripts/loadDb.ts` instead of `scripts/populateDb.ts`.